### PR TITLE
sort: fix ordering by date

### DIFF
--- a/src/components/search.js
+++ b/src/components/search.js
@@ -35,7 +35,7 @@ export function Search({ onChange, value, sort, onSortChange, ...props }) {
           borderColor: 'pink.200',
         }}
       >
-        <option value="desc" selected>
+        <option value="desc">
           Mais Recentes
         </option>
         <option value="asc">Mais Antigos</option>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,6 +3,7 @@ import { useStaticQuery, graphql } from 'gatsby'
 import * as JSSearch from 'js-search'
 import { useColorMode, Flex, Stack, IconButton } from '@chakra-ui/core'
 import { transformResults } from '../transformers/results'
+import SearchTermsSanitizer from '../utils/SearchTermsSanitizer'
 
 import Layout from '../components/layout'
 import SEO from '../components/seo'
@@ -12,7 +13,6 @@ import { Search } from '../components/search'
 import { Banner } from '../components/banner'
 import { Row } from '../components/row'
 import { Title } from '../components/title'
-import SearchTermsSanitizer from '../utils/SearchTermsSanitizer'
 
 function buildIndexes(data) {
   const search = new JSSearch.Search('id')
@@ -31,8 +31,8 @@ function buildIndexes(data) {
 }
 
 function sortByDate(order, list) {
-  if (order === 'asc') {
-    return [...list].sort((a, b) => a.date.localeCompare(b.date))
+  if (order === 'desc') {
+    return [...list].reverse()
   }
 
   return list
@@ -41,9 +41,7 @@ function sortByDate(order, list) {
 const IndexPage = () => {
   const data = useStaticQuery(graphql`
     query fetchPersons {
-      persons: allGoogleSheetRespostasAoFormulario1Row(
-        sort: { fields: carimbodedatahora, order: DESC }
-      ) {
+      persons: allGoogleSheetRespostasAoFormulario1Row {
         edges {
           node {
             id


### PR DESCRIPTION
Este PR faz uma alteração na forma como a ordenação funciona, atualmente faziamos um sorte diretamente na query do graphql da seguinte forma:

```gql
persons: allGoogleSheetRespostasAoFormulario1Row(sort: { fields: carimbodatahora, order: DESC })
```

O problema com isso é que o campo `carimbodatahora` é uma string e não uma data de verdade, então o problema com isso é que uma pessoa que se cadastrou em **31/07/2020** sempre iria aparecer como mais 'recente' do que quem se cadastrou no dia **25/08/2020** por exemplo.

Bem a solução implementada aqui é a seguinte `reverse`

O plugin que faz a query traz os registros na ordem que está a planilha, e a planilha sempre é ordenada dos mais antigos para os mais novos então a forma mais simples de ordenar isso é pegar este array de dados e aplicar um `reverse`

Este PR também remove a prop `selected` do options o chakra já usa o `value` pra resolver isso.