### PR TITLE
refactor: search

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -40,21 +40,36 @@ exports.createPages = async ({ graphql, actions }) => {
 
     fs.writeFileSync(
       path.resolve(DIR, `${page}.json`),
-      JSON.stringify({
-        nodes: persons.slice(begin, end),
-        pageInfo: { hasNextPage: page < pagesCount }
-      }, null, 2)
+      JSON.stringify(
+        {
+          nodes: persons.slice(begin, end),
+          pageInfo: { hasNextPage: page < pagesCount },
+        },
+        null,
+        2
+      )
     )
   })
 
+  fs.writeFileSync(
+    path.resolve(DIR, `all.json`),
+    JSON.stringify(
+      {
+        nodes: persons,
+      },
+      null,
+      2
+    )
+  )
+
   const initialData = {
     nodes: persons.slice(0, 8),
-    pageInfo: { hasNextPage: 1 < pagesCount, totalCount }
+    pageInfo: { hasNextPage: 1 < pagesCount, totalCount },
   }
 
   createPage({
     path: '/',
     component: path.resolve('./src/templates/home.js'),
-    context: initialData
+    context: initialData,
   })
 }

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -1,5 +1,12 @@
 import React, { useState, useMemo, useCallback } from 'react'
-import { useColorMode, Flex, Stack, IconButton, Button, Text } from '@chakra-ui/core'
+import {
+  useColorMode,
+  Flex,
+  Stack,
+  IconButton,
+  Button,
+  Text,
+} from '@chakra-ui/core'
 
 import { STATUS, useLoadMore } from '../hooks/useLoader'
 import { useSearch } from '../hooks/useSearch'
@@ -25,10 +32,10 @@ function sortByDate(order, list) {
 const IndexPage = ({ pageContext }) => {
   const { data, pageInfo, status, loadNextPage } = useLoadMore({
     initialData: pageContext.nodes,
-    initialPageInfo: pageContext.pageInfo
+    initialPageInfo: pageContext.pageInfo,
   })
   const { colorMode, toggleColorMode } = useColorMode()
-  const { onSearch, results, term } = useSearch({ data })
+  const { onSearch, results, term } = useSearch()
   const [sort, setSort] = useState(() => 'desc')
 
   const { totalCount } = pageContext.pageInfo
@@ -38,10 +45,11 @@ const IndexPage = ({ pageContext }) => {
     []
   )
 
-  const persons = useMemo(
-    () => ((term.length > 2) ? results : data),
-    [results, data, term]
-  )
+  const persons = useMemo(() => (term.length > 2 ? results : data), [
+    results,
+    data,
+    term,
+  ])
 
   const isLoading = status === STATUS.loading
   const shouldRenderLoadMoreButton = pageInfo.hasNextPage && term.length < 3
@@ -88,7 +96,9 @@ const IndexPage = ({ pageContext }) => {
             sort={sort}
           />
 
-          <Text>Você está visualizando {persons.length} pessoas de {totalCount}</Text>
+          <Text>
+            Você está visualizando {persons.length} pessoas de {totalCount}
+          </Text>
 
           <List>
             {sortByDate(sort, persons).map(person => (


### PR DESCRIPTION
A ideia desse PR é melhorar a experiência da busca. Hoje, ao buscar por um termo, a busca é feita apenas entre os itens carregados na página atual. Por ex: dos 8 carregados, só retorna 2 na busca. Fiz algumas alterações pra que passe a buscar na lista inteira de pessoas, assim retornando todos os resultados pro termo buscado.

PS: Seria legal ter uma paginação na busca também, mas ainda estou pensando em como seria a melhor forma de fazer.